### PR TITLE
Fix Jenkins RBAC to use ClusterRole

### DIFF
--- a/k8s.yaml
+++ b/k8s.yaml
@@ -22,7 +22,7 @@ spec:
       automountServiceAccountToken: true
       containers:
         - name: jenkins-master
-          image: microdc/k8s-jenkins:local
+          image: microdc/k8s-jenkins:latest
           ports:
             - containerPort: 8080
             - containerPort: 50000

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -181,6 +181,12 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "create"]
+  - apiGroups: [""]
+    resources: ["namespace", "namespaces"]
+    verbs: ["get", "patch", "create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -163,7 +163,7 @@ metadata:
   name: jenkins
   namespace: jenkins
 ---
-kind: Role
+kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: jenkins
@@ -171,6 +171,9 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["pods"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["deployments", "replicasets"]
     verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
   - apiGroups: [""]
     resources: ["pods/exec"]
@@ -183,14 +186,15 @@ rules:
     verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: jenkins
   namespace: jenkins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: jenkins
 subjects:
   - kind: ServiceAccount
     name: jenkins
+    namespace: jenkins

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -169,14 +169,11 @@ metadata:
   name: jenkins
   namespace: jenkins
 rules:
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
   - apiGroups: ["extensions"]
     resources: ["deployments", "replicasets"]
     verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
   - apiGroups: [""]
-    resources: ["pods/exec"]
+    resources: ["pods/exec", "pods"]
     verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
   - apiGroups: [""]
     resources: ["pods/log"]


### PR DESCRIPTION
Jenkins runs in Jenkins namespace. We do not run apps in this namespace.
In order for jenkins to be able to use kubectl to run and stop pods in
other namespaces, where the apps run, RBAC needs a ClusterRole here
instead of a Role (which can only do actions in the jenkins namespace).