### PR TITLE
Add an id of 'gitcreds' to the gitcreds SSH key

### DIFF
--- a/groovy/gitcreds.groovy
+++ b/groovy/gitcreds.groovy
@@ -15,7 +15,7 @@ String keyfile = "/var/jenkins_home/.ssh/id_rsa"
 
 privateKey = new BasicSSHUserPrivateKey(
 CredentialsScope.GLOBAL,
-null,
+'gitcreds',
 'gitcreds',
 new BasicSSHUserPrivateKey.FileOnMasterPrivateKeySource(keyfile),
 "",

--- a/groovy/settings.groovy
+++ b/groovy/settings.groovy
@@ -7,7 +7,7 @@ import hudson.security.csrf.DefaultCrumbIssuer
 import jenkins.security.s2m.AdminWhitelistRule
 
 // Set the number of Jenkins executors
-Jenkins.instance.setNumExecutors(1)
+Jenkins.instance.setNumExecutors(0)
 
 // Disable Jenkins CLI over remote
 Jenkins.instance.getDescriptor("jenkins.CLI").get().setEnabled(false)


### PR DESCRIPTION
This makes it simpler to refer to the gitcreds ssh key from scripted
jobs, which need it to clone their repos