### PR TITLE
Use tags not 'latest' for jenkins

### DIFF
--- a/k8s.yaml
+++ b/k8s.yaml
@@ -22,7 +22,7 @@ spec:
       automountServiceAccountToken: true
       containers:
         - name: jenkins-master
-          image: microdc/k8s-jenkins:latest
+          image: microdc/k8s-jenkins:2.2.3
           ports:
             - containerPort: 8080
             - containerPort: 50000
@@ -104,7 +104,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
         - name: jenkins-slave
-          image: microdc/jenkins-auto-jnlp-slave:1.0.0
+          image: microdc/jenkins-auto-jnlp-slave:1.0.1
           env:
             - name: JAVA_OPTS
               value: '-Xmx1400m'


### PR DESCRIPTION
- v. 2.2.3 of master with 0 executors on master and fixed git creds ID
- v. 1.0.1 of slaves with auto-registration logic if master dies