### PR TITLE
add jenkins-secret-env-vars for global secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,12 @@ kubectl create secret generic jenkins-ssh-config -n jenkins \
 kubectl create secret generic jenkins-admin-creds -n jenkins --from-literal=username=admin --from-literal=password=admin
 ```
 
-6. Access using the jenkins UI
+6. Add additional secrets to jenkins environment variables (key: value)
+```
+kubectl create secret generic jenkins-secret-env-vars -n jenkins --from-file="secrets.yaml"
+```
+
+7. Access using the jenkins UI
 `kubectl port-forward service/jenkins 8080 -n jenkins`
 
 

--- a/groovy/set-global-properties.groovy
+++ b/groovy/set-global-properties.groovy
@@ -1,8 +1,10 @@
 /*
 Setting Global properties (Environment variables)
 */
+@Grab('org.yaml:snakeyaml:1.17')
 import hudson.slaves.EnvironmentVariablesNodeProperty
 import jenkins.model.Jenkins
+import org.yaml.snakeyaml.Yaml
 
 instance = Jenkins.getInstance()
 globalNodeProperties = instance.getGlobalNodeProperties()
@@ -20,5 +22,13 @@ if ( envVarsNodePropertyList == null || envVarsNodePropertyList.size() == 0 ) {
 }
 println "Setting Global properties (Environment variables)"
 envVars.put("AWS_DEFAULT_REGION", "eu-west-1")
+
+// Load secrets if secrets.yaml is present
+def secretsfile = new File( '/usr/share/jenkins/secrets/secrets.yaml' )
+if( secretsfile.exists() ) {
+  Yaml parser = new Yaml()
+  HashMap secrets = parser.load(secretsfile.text)
+  secrets.each{ k, v -> envVars.put(k, v) }
+}
 
 instance.save()

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -61,6 +61,8 @@ spec:
               readOnly: true
             - mountPath: "/usr/share/jenkins/data"
               name: jenkins-git-repos
+            - mountPath: "/usr/share/jenkins/secrets"
+              name: jenkins-secret-env-vars
             - mountPath: /var/run/docker.sock
               name: docker-sock-volume
           resources:
@@ -82,6 +84,12 @@ spec:
             items:
               - key: repos.txt
                 path: repos.txt
+        - name: jenkins-secret-env-vars
+          secret:
+            secretName: jenkins-secret-env-vars
+            items:
+              - key: secrets.yaml
+                path: secrets.yaml
         - name: docker-sock-volume
           hostPath:
             path: /var/run/docker.sock


### PR DESCRIPTION
We have a requirement to add secrets for jobs to use. For instance,
service users for 3rd party services. Jenkins doesni't have a good way of
handling this so we mount them into the container at startup and set
them as variables. This probably needs a rethink as anyone with admin
access can see these secrets.