### PR TITLE
Add option to set a custom shell for jenkins pipelines

### DIFF
--- a/groovy/custom-shell.groovy
+++ b/groovy/custom-shell.groovy
@@ -1,0 +1,14 @@
+import hudson.tasks.*
+import jenkins.*
+import jenkins.model.*
+
+// Allows the user to set a different default shell for pipelines
+
+jenkins_shell = System.getenv("JENKINS_SHELL")
+
+if (jenkins_shell) {
+  jenkins = Jenkins.getInstance()
+  Shell.DescriptorImpl shell = jenkins.getExtensionList(Shell.DescriptorImpl.class).get(0)
+  shell.setShell("/bin/bash")
+  shell.save()
+}


### PR DESCRIPTION
If JENKINS_SHELL is not set, it defaults to bourne as per default
install