### PR TITLE
BUA Downgrade durable-task plugin

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -18,7 +18,7 @@ cucumber-reports:3.19.1
 display-url-api:2.2.0
 docker-commons:1.13
 docker-workflow:1.17
-durable-task:1.23
+durable-task:1.22
 external-monitor-job:1.7
 git-client:2.7.3
 git-parameter:0.9.3


### PR DESCRIPTION
Due to bug https://issues.jenkins-ci.org/browse/JENKINS-52859 we need to
downgrade durable-task plugin.