### PR TITLE
FIX update snakeyaml to 1.18

### DIFF
--- a/groovy/set-global-properties.groovy
+++ b/groovy/set-global-properties.groovy
@@ -1,7 +1,7 @@
 /*
 Setting Global properties (Environment variables)
 */
-@Grab('org.yaml:snakeyaml:1.17')
+@Grab('org.yaml:snakeyaml:1.18')
 import hudson.slaves.EnvironmentVariablesNodeProperty
 import jenkins.model.Jenkins
 import org.yaml.snakeyaml.Yaml


### PR DESCRIPTION
This was causing the script set-global-properties.groovy to fail when
jenkins starts so no global variables where being started.