### PR TITLE
Remove snakeyaml library dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ kubectl create secret generic jenkins-ssh-config -n jenkins \
 kubectl create secret generic jenkins-admin-creds -n jenkins --from-literal=username=admin --from-literal=password=admin
 ```
 
-6. Add additional secrets to jenkins environment variables (key: value)
+6. Add additional secrets to jenkins environment variables (key=value)
 ```
-kubectl create secret generic jenkins-secret-env-vars -n jenkins --from-file="secrets.yaml"
+kubectl create secret generic jenkins-secret-env-vars -n jenkins --from-file="secrets.properties"
 ```
 
 7. Access using the jenkins UI
@@ -122,4 +122,3 @@ curl -sSL "http://$JENKINS_HOST/pluginManager/api/xml?depth=1&xpath=/*/*/shortNa
           perl -pe 's/.*?<shortName>([\w-]+).*?<version>([^<]+)()(<\/\w+>)+/\1 \2\n/g'|sed 's/ /:/' | \
           sort
 ```
-

--- a/groovy/initseed.groovy
+++ b/groovy/initseed.groovy
@@ -21,7 +21,7 @@ Jenkins.instance.setNumExecutors(numberOfExecutors)
 // so it only runs the seed job and no other jobs.
 Jenkins.instance.setLabelString("master")
 
-if (System.getenv("DISABLE_EXCLUSIVE_MASTER")) ? System.getenv("DISABLE_EXCLUSIVE_MASTER").toBoolean(): true {
+if (System.getenv("DISABLE_EXCLUSIVE_MASTER") ? System.getenv("DISABLE_EXCLUSIVE_MASTER").toBoolean(): true) {
     Jenkins.instance.setMode(hudson.model.Node.Mode.EXCLUSIVE)
 }
 

--- a/groovy/initseed.groovy
+++ b/groovy/initseed.groovy
@@ -21,7 +21,7 @@ Jenkins.instance.setNumExecutors(numberOfExecutors)
 // so it only runs the seed job and no other jobs.
 Jenkins.instance.setLabelString("master")
 
-if(System.getenv("DISABLE_EXCLUSIVE_MASTER") ? System.getenv("DISABLE_EXCLUSIVE_MASTER").toBoolean(): true  {
+if (System.getenv("DISABLE_EXCLUSIVE_MASTER")) ? System.getenv("DISABLE_EXCLUSIVE_MASTER").toBoolean(): true {
     Jenkins.instance.setMode(hudson.model.Node.Mode.EXCLUSIVE)
 }
 

--- a/groovy/set-global-properties.groovy
+++ b/groovy/set-global-properties.groovy
@@ -2,20 +2,8 @@
 Setting Global properties (Environment variables)
 */
 
-proxyHost = System.getenv("HTTP_PROXY_HOST")
-proxyPort = System.getenv("HTTP_PROXY_PORT")
-
-if (proxyHost && proxyPort) {
-    System.properties.putAll([
-        'http.proxyHost':"${proxyHost}",
-        'http.proxyPort':"${proxyPort}"
-    ])
-}
-
-@Grab('org.yaml:snakeyaml:1.18')
 import hudson.slaves.EnvironmentVariablesNodeProperty
 import jenkins.model.Jenkins
-import org.yaml.snakeyaml.Yaml
 
 instance = Jenkins.getInstance()
 globalNodeProperties = instance.getGlobalNodeProperties()
@@ -34,12 +22,12 @@ if ( envVarsNodePropertyList == null || envVarsNodePropertyList.size() == 0 ) {
 println "Setting Global properties (Environment variables)"
 envVars.put("AWS_DEFAULT_REGION", "eu-west-1")
 
-// Load secrets if secrets.yaml is present
-def secretsfile = new File( '/usr/share/jenkins/secrets/secrets.yaml' )
-if( secretsfile.exists() ) {
-  Yaml parser = new Yaml()
-  HashMap secrets = parser.load(secretsfile.text)
-  secrets.each{ k, v -> envVars.put(k, v) }
+// Load secrets if secrets.properties is present
+def secretsFile = new File( '/usr/share/jenkins/secrets/secrets.properties' )
+if( secretsFile.exists() ) {
+  Properties properties = new Properties()
+  properties.load(secretsFile.newDataInputStream())
+  properties.each{ k, v -> envVars.put(k, v) }
 }
 
 instance.save()


### PR DESCRIPTION
@Grab does not work behind http proxy as it ignored http_proxy.
Jenkins does not support Grapes/Grab dependency framework in any case.

Removing snakeyaml, so we use in-built Properties processing to parse a Properties
file. All clients will need to move from yaml files to Properties files.