### PR TITLE
Fix logic of exclusive_master

### DIFF
--- a/groovy/initseed.groovy
+++ b/groovy/initseed.groovy
@@ -21,7 +21,7 @@ Jenkins.instance.setNumExecutors(numberOfExecutors)
 // so it only runs the seed job and no other jobs.
 Jenkins.instance.setLabelString("master")
 
-if (! System.getenv("DISABLE_EXCLUSIVE_MASTER") ? System.getenv("DISABLE_EXCLUSIVE_MASTER").toBoolean(): true) {
+if (! (System.getenv("DISABLE_EXCLUSIVE_MASTER") ? System.getenv("DISABLE_EXCLUSIVE_MASTER").toBoolean(): true)) {
     Jenkins.instance.setMode(hudson.model.Node.Mode.EXCLUSIVE)
 }
 


### PR DESCRIPTION
Previously the negative ("!") only applied to the first part of the statement,
so the master was still getting set in exclusive mode, even if
DISABLE_EXCLUSIVE_MASTER was set to true.

This change has been tested using the script console in Jenkins, and exhibits the
correct behaviour