### PR TITLE
Fix default behaviour of exclusive_master

### DIFF
--- a/groovy/initseed.groovy
+++ b/groovy/initseed.groovy
@@ -21,7 +21,7 @@ Jenkins.instance.setNumExecutors(numberOfExecutors)
 // so it only runs the seed job and no other jobs.
 Jenkins.instance.setLabelString("master")
 
-if (! (System.getenv("DISABLE_EXCLUSIVE_MASTER") ? System.getenv("DISABLE_EXCLUSIVE_MASTER").toBoolean(): true)) {
+if (! (System.getenv("DISABLE_EXCLUSIVE_MASTER") ? System.getenv("DISABLE_EXCLUSIVE_MASTER").toBoolean(): false)) {
     Jenkins.instance.setMode(hudson.model.Node.Mode.EXCLUSIVE)
 }
 


### PR DESCRIPTION
Client expect Jenkins master to be exclusive by default, unless they specify.
So here we change the default for DSIABLE_EXCLUSIVE_MASTER to false, so that
if clients do not specify, the exclusive master will not be disabled, and so
the master *will* be exclusive