### PR TITLE
Upgrade to latest version of Jenkins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN ./test.sh
 # Skip initial setup
 ENV JAVA_OPTS -Djenkins.install.runSetupWizard=false
 
-FROM jenkins/jenkins:2.145-alpine
+FROM jenkins/jenkins:2.162-alpine
 
 USER jenkins
 


### PR DESCRIPTION
This is primarily to address the recent Jenkins Security Advisories:
* https://jenkins.io/security/advisory/2018-12-05/
* https://jenkins.io/security/advisory/2019-01-16/