### PR TITLE
Fix security vulnerabilities in plugins

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -23,13 +23,13 @@ external-monitor-job:1.7
 git-client:2.7.3
 git-parameter:0.9.3
 git-server:1.7
-git:3.9.1
+git:3.9.3
 github-api:1.92
 github-branch-source:2.3.6
 github:1.29.2
 global-build-stats:1.5
 greenballs:1.15
-groovy:2.0
+groovy:2.1
 handlebars:1.1.1
 handy-uri-templates-2-api:2.1.6-1.0
 htmlpublisher:1.16
@@ -77,7 +77,7 @@ ssh-credentials:1.13
 structs:1.14
 throttle-concurrents:2.0.1
 timestamper:1.8.10
-token-macro:2.5
+token-macro:2.6
 variant:1.1
 windows-slaves:1.3.1
 workflow-aggregator:2.5

--- a/plugins.txt
+++ b/plugins.txt
@@ -59,7 +59,7 @@ pipeline-input-step:2.8
 pipeline-milestone-step:1.3.1
 pipeline-model-api:1.2.9
 pipeline-model-declarative-agent:1.1.1
-pipeline-model-definition:1.2.9
+pipeline-model-definition:1.3.5
 pipeline-model-extensions:1.2.9
 pipeline-rest-api:2.10
 pipeline-stage-step:2.3
@@ -72,7 +72,7 @@ resource-disposer:0.8
 role-strategy:2.8.1
 run-condition:1.0
 scm-api:2.2.7
-script-security:1.44
+script-security:1.50
 ssh-credentials:1.13
 structs:1.14
 throttle-concurrents:2.0.1
@@ -84,7 +84,7 @@ workflow-aggregator:2.5
 workflow-api:2.27
 workflow-basic-steps:2.7
 workflow-cps-global-lib:2.9
-workflow-cps:2.53
+workflow-cps:2.63
 workflow-durable-task-step:2.19
 workflow-job:2.21
 workflow-multibranch:2.19

--- a/plugins.txt
+++ b/plugins.txt
@@ -72,7 +72,7 @@ resource-disposer:0.8
 role-strategy:2.8.1
 run-condition:1.0
 scm-api:2.2.7
-script-security:1.50
+script-security:1.53
 ssh-credentials:1.13
 structs:1.14
 throttle-concurrents:2.0.1


### PR DESCRIPTION
A number of plugins defined in `plugins.txt` are using old versions that have known vulnerabilities. This PR brings these plugins in line with the newer versions that have fixed these issues.

Note that the only plugins updated are those that can be linked backed to published Jenkins Security Advisories, specifically:
* https://jenkins.io/security/advisory/2019-02-19/
* https://jenkins.io/security/advisory/2019-01-28/
* https://jenkins.io/security/advisory/2019-01-08/

No plugins have been updated just for the sake of it.