### PR TITLE
Remove AWS_DEFAULT_REGION override

### DIFF
--- a/groovy/set-global-properties.groovy
+++ b/groovy/set-global-properties.groovy
@@ -20,7 +20,6 @@ if ( envVarsNodePropertyList == null || envVarsNodePropertyList.size() == 0 ) {
   envVars = envVarsNodePropertyList.get(0).getEnvVars()
 }
 println "Setting Global properties (Environment variables)"
-envVars.put("AWS_DEFAULT_REGION", "eu-west-1")
 
 // Load secrets if secrets.properties is present
 def secretsFile = new File( '/usr/share/jenkins/secrets/secrets.properties' )


### PR DESCRIPTION
Currently we create AWS_DEFAULT_REGION env variable as part of the init groovy script
which blocks us from setting the same based on our setup. This will enable us to pass
the environment as part of the docker argument